### PR TITLE
Création de la base SQL + utilisateur  - Partie 2b.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Versionnage selon [Semantic Versioning](https://semver.org/lang/fr/).
       - [🔍 Etape 2 : Installation de l'environnement technique](#-etape-2--installation-de-lenvironnement-technique)
       - [🔍 Etape 3 : Construction du MRLD et alignement avec le MCD v2](#-etape-3--construction-du-mrld-et-alignement-avec-le-mcd-v2)
     - [🧭 Phase 2 - 2025-06-XX — Modèle logique (MRLD) \& base SQL](#-phase-2---2025-06-xx--modèle-logique-mrld--base-sql)
-      - [🚧 Etape 1 (2025-06-23) : Organisation documentaire et versionnning du SQL](#-etape-1-2025-06-23--organisation-documentaire-et-versionnning-du-sql)
+      - [🔍 Etape 1 (2025-06-23) : Organisation documentaire et versionnning du SQL](#-etape-1-2025-06-23--organisation-documentaire-et-versionnning-du-sql)
+      - [🔍 Etape 2 (2025-06-24) : Création Utilisateur et Base de données minimale fonctionnelle du SQL](#-etape-2-2025-06-24--création-utilisateur-et-base-de-données-minimale-fonctionnelle-du-sql)
       - [🚧 Etape \[Unreleased\] \[Phase 2 - v0.2\]](#-etape-unreleased-phase-2---v02)
   - [🧪 Milestone v0.3 - 2025-06-XX — Tests d’implémentation et jeu d’essai](#-milestone-v03---2025-06-xx--tests-dimplémentation-et-jeu-dessai)
     - [🧭 Phase \[Undefined\] - v0.3](#-phase-undefined---v03)
@@ -96,10 +97,21 @@ Versionnage selon [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### 🧭 Phase 2 - 2025-06-XX — Modèle logique (MRLD) & base SQL
 
-#### 🚧 Etape 1 (2025-06-23) : Organisation documentaire et versionnning du SQL
+#### 🔍 Etape 1 (2025-06-23) : Organisation documentaire et versionnning du SQL
 
 - Génération d'un dossier `/implementation/sql` pour gérer les versions du SQL
-- Initialisation des versions SQL à partir destravaux de tests des outils
+- Initialisation des versions SQL à partir des travaux de tests des outils
+- Ajout de l’historique technique : `HISTORIQUE_sql.md`
+- Suivi dans l’issue #5
+
+🗂️ Dossiers concernés : `/docs/implementation/`, `/sql/`
+
+#### 🔍 Etape 2 (2025-06-24) : Création Utilisateur et Base de données minimale fonctionnelle du SQL
+
+- Génération versions du SQL :
+  - `v0.1.1` : Base versionnée tifosi_v011 sécurisée par un utilisateur dédié (v0.1.2)
+  - `v0.1.2` : utilisateur `tifosi` (administrateur de la base v0.1.1)
+- Scripts de tests des versions
 - Ajout de l’historique technique : `HISTORIQUE_sql.md`
 - Suivi dans l’issue #5
 
@@ -110,7 +122,7 @@ Versionnage selon [Semantic Versioning](https://semver.org/lang/fr/).
 - Génération du script SQL complet dans `MPD_tifosi.sql`
 - Création d’un utilisateur `tifosi` avec droits associés
 - Ajout de l’historique technique : `HISTORIQUE_sql.md`
-- Suivi dans l’issue #4 et #5
+- Suivi dans l’issue #5
 
 🗂️ Dossiers concernés : `/docs/implementation/`, `/sql/`
 

--- a/docs/implementation/sql/HISTORIQUE_sql.md
+++ b/docs/implementation/sql/HISTORIQUE_sql.md
@@ -1,14 +1,17 @@
 # 🧾 Historique — Scripts SQL & Base de données
 
 _Rédigé par :_ PerLucCo  
-_Dernière mise à jour :_ 23 juin 2025  
+_Dernière mise à jour :_ 24 juin 2025  
 
 ---
 
 - [🧾 Historique — Scripts SQL \& Base de données](#-historique--scripts-sql--base-de-données)
   - [✅ V0 – Script de création initiale de la base Tifosi (2025-06-18)](#-v0--script-de-création-initiale-de-la-base-tifosi-2025-06-18)
   - [✅ V0.0 – Réorganisation documentaire et du versionnement des scripts (2025-06-23)](#-v00--réorganisation-documentaire-et-du-versionnement-des-scripts-2025-06-23)
-  - [🚧 V0.1 – Réorganisation documentaire et du versionnement des scripts (2025-06-XX)](#-v01--réorganisation-documentaire-et-du-versionnement-des-scripts-2025-06-xx)
+  - [🚫 V0.1 – Section absorbée par les versions détaillées suivantes](#-v01--section-absorbée-par-les-versions-détaillées-suivantes)
+  - [✅ V0.1.1 – Modélisation relationnelle et implémentation physique (2025-06-23)](#-v011--modélisation-relationnelle-et-implémentation-physique-2025-06-23)
+  - [✅ V0.1.2 – Sécurisation de la base versionnée via utilisateur `tifosi` (2025-06-25)](#-v012--sécurisation-de-la-base-versionnée-via-utilisateur-tifosi-2025-06-25)
+  - [🚧 V0.1.3 – Base de données complète avec  Utilisateur administrateur `tifosi` (2025-06-XX)](#-v013--base-de-données-complète-avec--utilisateur-administrateur-tifosi-2025-06-xx)
 
 ---
 
@@ -21,22 +24,65 @@ _Dernière mise à jour :_ 23 juin 2025
 🗓️ Commit : [`d24924fc`](github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/commit/d24924fc)
 📌 Issue liée : [#3](https://github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/issues/3)
 
+---
+
 ## ✅ V0.0 – Réorganisation documentaire et du versionnement des scripts (2025-06-23)
 
 - Déplacement de la version _V0_ et mise en place du versionning des implémentations SQL.
 
 📎 Fichier produit : `create_tifosi.sql`  
-🚧🗓️ Commit : [`<hashs>`](github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/commit/[`<hashs>`])
+🗓️ Commit : [ff7dc352](github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/commit/ff7dc352)
 📌 Issue liée : [#5](https://github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/issues/5)
 
-## 🚧 V0.1 – Réorganisation documentaire et du versionnement des scripts (2025-06-XX)
+---
 
-- Génération du script `create_tifosi.sql` selon le MRLD v1
-- Déclaration des tables, types SQL et contraintes d’intégrité
-- Mise en place des clés primaires et étrangères
-- Bloc de création de la base de données `tifosi`
-- Bloc de création de l’utilisateur `tifosi` avec droits `GRANT`
+## 🚫 V0.1 – Section absorbée par les versions détaillées suivantes
 
-📎 Fichier produit : `create_tifosi.sql`  
-🗓️ Commit : [`<hashs>`](github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/commit/[`<hashs>`])
+Cette étape intermédiaire a été décomposée plus précisément en :
+
+- ✅ V0.1.1 : Création de la structure SQL (base `tifosi_v011`)
+- ✅ V0.1.2 : Sécurisation via utilisateur `tifosi`
+
+➡️ Voir les sections correspondantes pour le détail des fichiers et des commits.
+
+---
+
+## ✅ V0.1.1 – Modélisation relationnelle et implémentation physique (2025-06-23)
+
+- Création des tables relationnelles selon le MRLD v1
+- Déclaration des types SQL, clés primaires et étrangères
+- Construction des relations N:N : `clients_jours_menus` et `clients_focaccias_jours`
+- Génération de la base `tifosi_v011` comme base versionnée de conception
+
+📎 Fichiers produits :
+
+- `create_tifosi.sql`
+- `MPD-v0.1.1_tifosi.md`
+
+🗓️ Commit : [df85b10f](github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/commit/df85b10f)  
 📌 Issue liée : [#5](https://github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/issues/5)
+
+---
+
+## ✅ V0.1.2 – Sécurisation de la base versionnée via utilisateur `tifosi` (2025-06-25)
+
+- Création de l’utilisateur `tifosi`, administrateur métier local de la base `tifosi_v011`
+- Attribution des droits complets (`ALL PRIVILEGES`), avec **GRANT OPTION révoqué**
+- Mise en place d’un script d’initialisation complet : `init_v012.sql`
+- Rédaction des fichiers de définition (`README_user`) et de test (`README_test`)
+- Documentation complète dans `MPD-v0.1.2_tifosi.md`
+
+📎 Fichiers produits :
+
+- `create_user_tifosi.sql`
+- `init_v012.sql`
+- `README_user-v0.1.2.md`
+- `README_test-v0.1.2.md`
+- `MPD-v0.1.2_tifosi.md`
+
+🗓️ Commit : prévu dans `partial fix #5 (2b)`  
+📌 Issue liée : [#5](https://github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/issues/5)
+
+---
+
+## 🚧 V0.1.3 – Base de données complète avec  Utilisateur administrateur `tifosi` (2025-06-XX)

--- a/docs/implementation/sql/README_sql.md
+++ b/docs/implementation/sql/README_sql.md
@@ -1,22 +1,39 @@
 # 🧮 Scripts SQL du projet Tifosi
 
 _Rédigé par :_ PerLucCo  
-_Dernière mise à jour :_ 23 juin 2025  
+_Dernière mise à jour :_ 24 juin 2025  
 
 Ce répertoire contient tous les fichiers SQL liés à la base de données `tifosi`, manipulés dans le cadre du devoir.
 
 ---
 
 - [🧮 Scripts SQL du projet Tifosi](#-scripts-sql-du-projet-tifosi)
-  - [📂 Fichiers présents](#-fichiers-présents)
-  - [🔍 Légende des états](#-légende-des-états)
-  - [♻️ Gestion de versions](#️-gestion-de-versions)
-    - [Principes et suivis](#principes-et-suivis)
-    - [Plan de réalisation](#plan-de-réalisation)
+  - [📂 1-Fichiers attendus](#-1-fichiers-attendus)
+    - [📦 1.1- Etat d'avancement](#-11--etat-davancement)
+    - [🔍 1.2- Légende des états](#-12--légende-des-états)
+  - [♻️ 2- Gestion de versions](#️-2--gestion-de-versions)
+    - [🛠️ 2.1- Principes et suivis](#️-21--principes-et-suivis)
+    - [🧭 2.2- Plan de réalisation](#-22--plan-de-réalisation)
+      - [🪜 2.2.1- Versions du projet](#-221--versions-du-projet)
+      - [🔧 2.2.2- Etapes de réalisation](#-222--etapes-de-réalisation)
+        - [📐 Étape 1 — MPD v0 (liée à #5)](#-étape-1--mpd-v0-liée-à-5)
+        - [🧱 Étape 2 — MPD partiel : v0.1.1 + v0.1.2 (liée à #5)](#-étape-2--mpd-partiel--v011--v012-liée-à-5)
+          - [🧱 v0.1.1 – Base fonctionnelle minimale](#-v011--base-fonctionnelle-minimale)
+          - [🛡️ v0.1.2 – Sécurité applicative](#️-v012--sécurité-applicative)
+        - [🧩 Étape 3 — MPD complet : v0.1.3 (liée à #5)](#-étape-3--mpd-complet--v013-liée-à-5)
+        - [🧬 Étape 4 — Insertion des données (liée à #6)](#-étape-4--insertion-des-données-liée-à-6)
+        - [🧪 Étape 5 — Requêtes de test et sauvegarde (liée à #7)](#-étape-5--requêtes-de-test-et-sauvegarde-liée-à-7)
+        - [📦 Étape 6 — Finalisation documentaire et livraison (liée à #7)](#-étape-6--finalisation-documentaire-et-livraison-liée-à-7)
+  - [🔗 3 - Suivi des travaux en cours (issues GitHub)](#-3---suivi-des-travaux-en-cours-issues-github)
+    - [🟢 #5 — Création de la base SQL + utilisateur `issue #5`](#-5--création-de-la-base-sql--utilisateur-issue-5)
+    - [🟠 #6 — Insertion des données `issue #6`](#-6--insertion-des-données-issue-6)
+    - [🟠 #7 — Requêtes de test, sauvegarde et documentation `issue #7`](#-7--requêtes-de-test-sauvegarde-et-documentation-issue-7)
 
 ---
 
-## 📂 Fichiers présents
+## 📂 1-Fichiers attendus
+
+### 📦 1.1- Etat d'avancement
 
 | Fichier | Rôle | État | Version |
 |--|--|--|--|
@@ -24,26 +41,33 @@ Ce répertoire contient tous les fichiers SQL liés à la base de données `tifo
 | insert_data.sql  | Insertion des données de test | À venir | — |
 | backup_tifosi.sql | Sauvegarde complète | À venir | — |
 
-## 🔍 Légende des états
+>🔗 Pour consulter les issues GitHub en cours liées à ces fichiers, voir [Section 3 – Suivi des travaux en cours](#-3---suivi-des-travaux-en-cours-issues-github)
+
+### 🔍 1.2- Légende des états
 
 - `À initialiser` : squelette créé mais non fonctionnel
 - `En cours` : structure validée, contenu partiel
 - `À tester` : script finalisé mais non validé
 - `Prêt` : prêt pour la livraison finale
 
-## ♻️ Gestion de versions
+---
 
-### Principes et suivis
+## ♻️ 2- Gestion de versions
+
+### 🛠️ 2.1- Principes et suivis
 
 - Chaque évolution (ajout, correction, refactoring) fait l’objet d’une PR avec mise à jour de ce fichier.
 - Versionnement géré manuellement par étiquette `vX.Y.Z`
 
 Le suivi des versions est défini dans [`HISTORIQUE_sql.md`](HISTORIQUE_sql.md).
 
-### Plan de réalisation
+---
+
+### 🧭 2.2- Plan de réalisation
+
+#### 🪜 2.2.1- Versions du projet
 
 Ce projet suit une logique de montée progressive en complexité, avec des versions incrémentales de la base `tifosi`.  
-Chaque version est placée dans un sous-dossier `sql-vX.Y` ou `sql-vX.Y.Z`.
 
 | Version SQL | Objectif principal  | Description | Dossier associé |
 |--|--|--|--|
@@ -53,5 +77,165 @@ Chaque version est placée dans un sous-dossier `sql-vX.Y` ou `sql-vX.Y.Z`.
 | v0.1.2 | Création de l’utilisateur `tifosi` | Sécurité applicative (`CREATE USER`, `GRANT`) | à venir |
 | v0.1.3 | MPD complet  | Intégration des marques, ingrédients, relations N:N complètes | à venir |
 | v0.2.x  | Données, insertions, tests | `insert_data.sql`, export `.sql`, validations | à venir |
+
+>Chaque version est placée dans un sous-dossier `sql-vX.Y` ou `sql-vX.Y.Z`.
+
+---
+
+#### 🔧 2.2.2- Etapes de réalisation
+
+Les étapes de construction logique et physique de la base `tifosi` sont en relation avec la modélisation métier et les tests d’usage. Elle structure la montée en complexité du modèle relationnel et des scripts SQL. Elles sont réalisées sur plusieurs étapes établies dans plusieurs _issues_ du projet :
+
+- [#5](https://github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/issues/5) : Création de la base SQL et de l'utilisateur
+- [#6](https://github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/issues/6) : Insertion des données
+- [#7](https://github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/issues/7) : Requêtes de test, sauvegarde et documentation.
+
+---
+
+##### 📐 Étape 1 — MPD v0 (liée à #5)
+
+🎯 Objectif : Vérification des outils de génération SQL (Workbench, scripts `.sql`, encodage, moteur InnoDB)
+
+- Création manuelle d’une base avec une seule table
+- Script de test de création, suppression, requête simple
+- But purement technique, sans modèle fonctionnel associé
+
+📁 Dossier concerné : `sql-v0.0/`  
+📄 Fichier : `create_tifosi_v00.sql`
+
+---
+
+##### 🧱 Étape 2 — MPD partiel : v0.1.1 + v0.1.2 (liée à #5)
+
+🎯 Objectif : Implémenter une base partielle conforme au **MRLD v1.1**, validée avec l’utilisateur SQL `tifosi`
+
+###### 🧱 v0.1.1 – Base fonctionnelle minimale
+
+- Tables : `clients`, `menus`, `focaccias`, `jours`
+- Relations ternaires : `clients_jours_menus`, `clients_focaccias_jours`
+- Script SQL testé manuellement
+- Requête d'insertion + lecture validées
+
+📁 Dossier : `sql-v0.1/versions/sql-v0.1.1/`  
+📄 Fichiers :
+
+- `MPD-v0.1.1.drawio`, `create_tifosi.sql`
+- `README_test-v0.1.1.md`
+
+###### 🛡️ v0.1.2 – Sécurité applicative
+
+- Création de l'utilisateur SQL `tifosi`
+- Attribution des droits (définis par défaut comme administrateur)
+- Documentation des privilèges effectifs
+- Exploitation de la base de données en version fonctionnelle minimale (v0.1.1)
+
+📁 Dossier : `sql-v0.1/versions/sql-v0.1.2/`  
+📄 Fichier attendu : `create_user_tifosi.sql`
+
+---
+
+##### 🧩 Étape 3 — MPD complet : v0.1.3 (liée à #5)
+
+🎯 Objectif : Construire une base complète alignée sur **MRLD v1.1** et conforme à **MCD v2.1**
+
+- Ajout des entités : `ingredients`, `marques`, `utilisateurs` (si retenus)
+- Relations complexes :
+  - `menus ↔ ingredients` (`compose`)
+  - `clients ↔ menus` (`paye` avec `montant`, `date`)
+  - `clients ↔ menus` (`note` avec `valeur`)
+- Intégration des attributs relationnels
+
+📁 Dossier prévu : `sql-v0.1/versions/sql-v0.1.3/`  
+📄 Fichiers attendus :
+
+- `MPD-v0.1.3.drawio` / `create_tifosi_v013.sql`
+- `README_test-v0.1.3.md`
+
+---
+
+##### 🧬 Étape 4 — Insertion des données (liée à #6)
+
+🎯 Objectif : Ajouter des données réelles ou fictives dans les tables afin de permettre les tests applicatifs sur la base complète.
+
+- Insertion contrôlée (respect des clés étrangères et des formats)
+- Données variées : clients, menus, focaccias, jours, marques, ingrédients
+- Possibilité d’automatiser via un script `insert_data.sql`
+
+📁 Dossier prévu : `sql-v0.2/`  
+📄 Fichier attendu : `insert_data.sql`
+
+---
+
+##### 🧪 Étape 5 — Requêtes de test et sauvegarde (liée à #7)
+
+🎯 Objectif : Vérifier la consistance de la base via des requêtes SQL et produire une sauvegarde `.sql` prête pour la livraison.
+
+- Écriture de requêtes de sélection, de jointures, de filtres
+- Validation des comportements fonctionnels (commandes, paiements, notes)
+- Génération d’une sauvegarde MySQL complète : `backup_tifosi.sql`
+
+📁 Dossier visé : `sql-v0.2/` ou `sql-v1.0/`  
+📄 Fichiers attendus :
+
+- `requêtes_test.sql`
+- `backup_tifosi.sql`
+- `README_test-v1.0.md`
+
+---
+
+##### 📦 Étape 6 — Finalisation documentaire et livraison (liée à #7)
+
+🎯 Objectif : Compiler tous les éléments documentaires techniques en vue de la livraison
+
+- Génération du script final `create_tifosi.sql` complet
+- Résumé des tests effectués et validés
+- Dépôt dans `/docs/livraison/` ou équivalent
+
+📄 Fichiers attendus :
+
+- `README_sql.md` final
+- `HISTORIQUE_sql.md` à jour
+- `CONVENTION_BDD.md` stabilisé
+
+---
+
+## 🔗 3 - Suivi des travaux en cours (issues GitHub)
+
+### 🟢 #5 — Création de la base SQL + utilisateur [`issue #5`](https://github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/issues/5)
+
+🎯 **Objectif** : Écriture du script SQL de la base Tifosi (tables, clés, contraintes) + définition de l'utilisateur `tifosi`.
+
+📌 **État** : En cours de finalisation – partie 2b (script utilisateur)  
+📦 Étapes réalisées : MPD v0.1.1, `README_test-v0.1.1.md`, MPD v0.1.2 en préparation  
+📂 Versions concernées : `sql-v0.1.1`, `sql-v0.1.2`, `sql-v0.1.3`
+
+---
+
+### 🟠 #6 — Insertion des données [`issue #6`](https://github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/issues/6)
+
+🎯 **Objectif** : Fournir des données de test réalistes pour valider les comportements métier de la base.
+
+📌 **État** : À venir  
+📦 Travaux attendus : `insert_data.sql`, validations de contraintes, cohérence inter-tables  
+📂 Dossier cible : `sql-v0.2/`
+
+---
+
+### 🟠 #7 — Requêtes de test, sauvegarde et documentation [`issue #7`](https://github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/issues/7)
+
+🎯 **Objectif** : Produire les requêtes d’évaluation, vérifier la consistance métier, exporter la base complète (`backup_tifosi.sql`) et finaliser la documentation technique.
+
+📌 **État** : À venir  
+📦 Travaux attendus :
+
+- `requêtes_test.sql`
+- `README_test-v1.0.md`
+- `backup_tifosi.sql`  
+📂 Dossiers concernés : `sql-v0.2/`, `docs/livraison/`
+
+---
+
+📁 Voir l’ensemble des issues du projet :  
+→ [Onglet Issues GitHub](https://github.com/MonLucCo/CEF_MySQL-BDD_Tifosi_Test-version/issues)
 
 ---

--- a/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/MPD-v0.1.2_tifosi.md
+++ b/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/MPD-v0.1.2_tifosi.md
@@ -1,0 +1,98 @@
+# 🗂️ MPD v0.1.2 — Base `tifosi` + sécurité (création utilisateur)
+
+---
+
+- [🗂️ MPD v0.1.2 — Base `tifosi` + sécurité (création utilisateur)](#️-mpd-v012--base-tifosi--sécurité-création-utilisateur)
+  - [🎯 Objectif](#-objectif)
+  - [🧱 Structure SQL héritée](#-structure-sql-héritée)
+  - [🔐 Spécificité de la version v0.1.2](#-spécificité-de-la-version-v012)
+    - [🛡️ Administrateur de la base : Utilisateur `tifosi`](#️-administrateur-de-la-base--utilisateur-tifosi)
+    - [📎 Documentation associée](#-documentation-associée)
+    - [⚙️ Initialisation automatisée](#️-initialisation-automatisée)
+    - [🧪 Portée des tests associés](#-portée-des-tests-associés)
+  - [🧭 Conclusion](#-conclusion)
+
+---
+
+## 🎯 Objectif
+
+Cette version assure la transition entre la structure relationnelle partielle de la base (`v0.1.1`) et la mise en place d’un environnement sécurisé via la création de l’utilisateur `tifosi`.
+
+Aucun changement n’est apporté à la structure du schéma physique. L’évolution porte exclusivement sur l’attribution de privilèges adaptés pour une gestion autonome de la base.
+
+---
+
+## 🧱 Structure SQL héritée
+
+La structure relationnelle (tables, clés, relations N:N) est strictement identique à celle de la version `v0.1.1` :
+
+- Entités : `clients`, `menus`, `focaccias`, `jours`
+- Relations N:N :
+  - `clients_jours_menus`
+  - `clients_focaccias_jours`
+- Contraintes : clés primaires, clés étrangères, unicité
+
+📎 Structure initialement définie dans :  
+[`MPD-v0.1.1_tifosi.md`](../sql-v0.1.1/MPD-v0.1.1_tifosi.md)
+
+---
+
+## 🔐 Spécificité de la version v0.1.2
+
+### 🛡️ Administrateur de la base : Utilisateur `tifosi`
+
+- Créé par le script : `create_user_tifosi.sql`
+- Privilèges accordés : `ALL PRIVILEGES ON tifosi.*`
+- Droit de délégation (`GRANT OPTION`) : **révoqué**
+- Limitation à l’hôte : `'localhost'`
+- Mot de passe : défini dans le script selon les consignes de sécurité
+
+### 📎 Documentation associée
+
+- [README_user-v0.1.2.md](README_user-v0.1.2.md) : définition, rôle, justification des droits
+- [README_test-v0.1.2.md](README_test-v0.1.2.md) : protocole de test de connexion et d’exécution
+- [create_user_tifosi.sql](create_user_tifosi.sql) : script SQL principal de l’étape
+- [init_v012](init_v012.sql) : script d'automatisation de l'initialisation de la base de données
+
+---
+
+### ⚙️ Initialisation automatisée
+
+La version `v0.1.2` peut être installée en une seule commande grâce au fichier `init_v012.sql`.
+
+Ce script enchaîne deux étapes :
+
+1. La création de la base `tifosi_v011` et de sa structure (`create_tifosi.sql`)
+2. La création de l’utilisateur `tifosi` et l’attribution de ses privilèges (`create_user_tifosi.sql`)
+
+📁 Emplacement : `sql-v0.1/versions/sql-v0.1.2/init_v012.sql`
+
+📌 Commande d’exécution recommandée (depuis le terminal) :
+
+Début bash :  
+mysql -u root -p < init_v012.sql  
+Fin bash
+
+⚠️ Remarque : le script doit être exécuté par un utilisateur SQL disposant des droits `CREATE`, `CREATE USER` et `GRANT`.
+
+L’environnement complet de la version `v0.1.2` est ainsi initialisé de manière reproductible, prêt à être utilisé pour les tests métier via le compte `tifosi`.
+
+### 🧪 Portée des tests associés
+
+L’utilisateur `tifosi` est capable de :
+
+- Créer, modifier, supprimer toutes les tables de la base
+- Insérer et manipuler des données
+- Exécuter des requêtes de lecture complexes
+- Gérer les contraintes, clés, index
+
+Il ne peut pas :
+
+- Intervenir sur les bases `mysql`, `information_schema`, etc.
+- Redistribuer ses droits via `GRANT ... TO`
+
+---
+
+## 🧭 Conclusion
+
+La version `v0.1.2` établit la couche de sécurité nécessaire à la poursuite du projet dans un contexte réaliste. Elle constitue une étape autonome dans l’évolution contrôlée de la base `tifosi`, avant sa généralisation fonctionnelle en `v0.1.3`.

--- a/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/README_test-v0.1.2.md
+++ b/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/README_test-v0.1.2.md
@@ -1,0 +1,93 @@
+# 🧪 Tests de validation — Étape v0.1.2
+
+---
+
+- [🧪 Tests de validation — Étape v0.1.2](#-tests-de-validation--étape-v012)
+  - [🎯 Objectif](#-objectif)
+  - [🚀 Initialisation complète](#-initialisation-complète)
+  - [🧪 Protocole de test](#-protocole-de-test)
+  - [✅ Résultats attendus](#-résultats-attendus)
+  - [📎 Fichiers liés](#-fichiers-liés)
+
+---
+
+## 🎯 Objectif
+
+Vérifier que l’utilisateur SQL `tifosi`, créé via le script `create_user_tifosi.sql`, possède bien tous les privilèges sur la base `tifosi_v011`, à l’exclusion du droit de délégation (`GRANT OPTION`), conformément aux exigences du sujet.
+
+---
+
+## 🚀 Initialisation complète
+
+Avant de tester les droits de l’utilisateur `tifosi`, il est possible d’initialiser automatiquement la base `tifosi_v011` à l’aide du fichier suivant :
+
+Fichier : `init_v012.sql`
+
+Commande d’exécution depuis le terminal :
+
+Début bash :  
+mysql -u root -p < init_v012.sql  
+Fin bash
+
+Ce script exécute successivement :
+
+1. la création de la base `tifosi_v011` et de sa structure (`create_tifosi.sql`)  
+2. la création de l’utilisateur `tifosi` et l’attribution de ses privilèges (`create_user_tifosi.sql`)
+
+La base est alors prête à être utilisée avec l’utilisateur `tifosi` pour les tests décrits ci-dessus.
+
+---
+
+## 🧪 Protocole de test
+
+1. Connexion à MySQL avec l’utilisateur `tifosi` :
+
+    ```bash
+    mysql -u tifosi -p
+    ```
+
+2. Accès à la base `tifosi_v011` :
+
+    ```sql
+    SHOW DATABASES;
+    USE tifosi_v011;
+    ```
+
+3. Test des droits complets sur la base :
+
+    ```sql
+    CREATE TABLE test_table (id INT);
+    INSERT INTO test_table VALUES (1);
+    SELECT * FROM test_table;
+    DROP TABLE test_table;
+    Fin SQL
+    ```
+
+4. Vérification de l’absence de droits sur les bases système :
+
+    ```sql
+    USE mysql;
+    ```
+
+5. Vérification de l’impossibilité de délégation des droits :
+
+    ```sql
+    GRANT SELECT ON tifosi_v011.* TO 'autre_user'@'localhost';
+    ```
+
+---
+
+## ✅ Résultats attendus
+
+- La base `tifosi_v011` est visible et utilisable par l’utilisateur `tifosi`
+- Toutes les commandes sur cette base sont autorisées
+- L’accès à d’autres bases système est interdit
+- La commande GRANT échoue pour l’utilisateur `tifosi`
+
+---
+
+## 📎 Fichiers liés
+
+- [create_user_tifosi.sql](create_user_tifosi.sql) : script de création du compte `tifosi`
+- [README_user-v0.1.2.md](README_user-v0.1.2.md) : définition et justification des privilèges
+- [MPD-v0.1.2.md](MPD-v0.1.2_tifosi.md) : référence structurelle de la version

--- a/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/README_user-v0.1.2.md
+++ b/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/README_user-v0.1.2.md
@@ -1,0 +1,101 @@
+# 🔐 Utilisateur SQL `tifosi` — Étape v0.1.2
+
+---
+
+- [🔐 Utilisateur SQL `tifosi` — Étape v0.1.2](#-utilisateur-sql-tifosi--étape-v012)
+  - [🎯 Objectif](#-objectif)
+  - [🔐 Privilèges accordés](#-privilèges-accordés)
+  - [🧪 Portée des droits](#-portée-des-droits)
+  - [🗝️ Utilisation prévue](#️-utilisation-prévue)
+  - [🚀 Initialisation automatisée avec `init_v012.sql`](#-initialisation-automatisée-avec-init_v012sql)
+  - [📎 Fichiers liés](#-fichiers-liés)
+
+---
+
+## 🎯 Objectif
+
+Mettre en œuvre un utilisateur SQL nommé `tifosi`, défini comme administrateur métier de la base de données `tifosi`, conformément aux attendus du sujet.
+
+Dans cette phase de conception, il s'agit de créer un compte SQL `tifosi`, administrateur **local sur la base versionnée `tifosi_v011`**, pour mener les tests de conception métier sans utiliser root.
+
+L'administrateur de la base, l'utilisateur `tifosi` doit :
+
+- être restreint à la base `tifosi_v011`
+- disposer de tous les droits sur cette base
+- ne pas avoir de privilèges sur d’autres bases (ex : `mysql`, `information_schema`)
+- ne pas pouvoir déléguer ses privilèges (GRANT OPTION désactivé)
+
+> ℹ️ L’utilisateur tifosi sera réutilisé et étendu à partir de la version v0.1.3, puis consolidé définitivement en v0.2.x.
+
+---
+
+## 🔐 Privilèges accordés
+
+Les instructions SQL suivantes sont utilisées :
+
+```sql
+CREATE USER 'tifosi'@'localhost' IDENTIFIED BY 'TifosiPwd_24';
+
+GRANT ALL PRIVILEGES ON tifosi_v011.* TO 'tifosi'@'localhost';
+
+REVOKE GRANT OPTION ON tifosi_v011.* FROM 'tifosi'@'localhost';
+
+FLUSH PRIVILEGES;
+```
+
+🔎 Justification :
+
+- `GRANT ALL PRIVILEGES ON tifosi.*` permet à `tifosi` de gérer les objets de la base : création, modification, suppression.
+- Le `REVOKE GRANT OPTION` désactive la capacité à transférer ses droits à d’autres comptes.
+- Ces droits respectent strictement la phrase du sujet : *“tous les droits sur la base de données tifosi”* — sans extrapoler à des privilèges d’administration serveur.
+
+---
+
+## 🧪 Portée des droits
+
+- ✅ Lecture / écriture / gestion des structures (`CREATE`, `DROP`, `ALTER`) autorisés
+- 🚫 Droits refusés sur : `mysql`, `information_schema`, `performance_schema`
+- 🚫 Requête `GRANT ... TO` impossible pour `tifosi`
+
+---
+
+## 🗝️ Utilisation prévue
+
+- Connexion par `tifosi` dans MySQL Workbench ou terminal
+- Exécution de tous les scripts SQL du projet
+- Vérification applicative et requêtes de test
+- Vérifications manuelles via Workbench, terminal, ou exports
+- Sauvegarde via export MySQL standard
+
+---
+
+## 🚀 Initialisation automatisée avec `init_v012.sql`
+
+Pour faciliter la mise en place de la version `v0.1.2` (base + utilisateur), le fichier `init_v012.sql` enchaîne automatiquement :
+
+1. La création de la base `tifosi_v011` et de sa structure (via `create_tifosi.sql`)
+2. La création de l’utilisateur `tifosi` avec tous les privilèges sur cette base (via `create_user_tifosi.sql`)
+
+Le fichier est conçu pour être exécuté en une seule commande à partir de la racine du dossier `sql-v0.1/versions/sql-v0.1.2/`.
+
+**Commande d’exécution :**
+
+```bash  
+mysql -u root -p < init_v012.sql  
+```
+
+**Conditions :**
+
+- L’utilisateur exécutant doit disposer du droit `CREATE USER` et `GRANT`
+- Les fichiers `create_tifosi.sql` et `create_user_tifosi.sql` doivent être présents dans le même dossier que `init_v012.sql`
+
+L’exécution terminée, la base `tifosi_v011` est prête à être utilisée avec le compte `tifosi`.
+
+---
+
+## 📎 Fichiers liés
+
+- [init_v012.sql](init_v012.sql) : script d'initialisation automatisée de la version v0.1.2
+- [create_user_tifosi.sql](create_user_tifosi.sql) : script SQL d’instanciation
+- [README_test-v0.1.2.md](README_test-v0.1.2.md) : protocole de vérification
+- [MPD-v0.1.2.md](MPD-v0.1.2_tifosi.md) : référence structurelle du modèle concerné

--- a/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/create_tifosi.sql
+++ b/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/create_tifosi.sql
@@ -1,0 +1,77 @@
+-- 🧱 Script create_tifosi.sql — Version MPD v0.1.1
+-- Auteur : PerLucCo
+-- Date : 2025-06-24
+
+-- 🔧 Création de la base
+CREATE DATABASE IF NOT EXISTS tifosi_v011 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+USE tifosi_v011;
+
+-- =====================
+-- Table : clients
+-- =====================
+CREATE TABLE clients (
+    id_client INT AUTO_INCREMENT PRIMARY KEY,
+    nom_client VARCHAR(45) NOT NULL,
+    age INT
+) ENGINE = InnoDB;
+
+-- =====================
+-- Table : jours
+-- =====================
+CREATE TABLE jours (
+    id_jour INT AUTO_INCREMENT PRIMARY KEY,
+    date_jour DATE NOT NULL UNIQUE
+) ENGINE = InnoDB;
+
+-- =====================
+-- Table : focaccias
+-- =====================
+CREATE TABLE focaccias (
+    id_focaccia INT AUTO_INCREMENT PRIMARY KEY,
+    nom_focaccia VARCHAR(45) NOT NULL,
+    prix_focaccia DECIMAL(5, 2) NOT NULL
+) ENGINE = InnoDB;
+
+-- =====================
+-- Table : menus
+-- =====================
+CREATE TABLE menus (
+    id_menu INT AUTO_INCREMENT PRIMARY KEY,
+    nom_menu VARCHAR(45) NOT NULL,
+    prix_menu DECIMAL(5, 2) NOT NULL,
+    focaccia_id INT,
+    FOREIGN KEY (focaccia_id) REFERENCES focaccias (id_focaccia) ON DELETE SET NULL
+) ENGINE = InnoDB;
+
+-- ================================
+-- Table : clients_jours_menus
+-- Relation ternaire
+-- ================================
+CREATE TABLE clients_jours_menus (
+    client_id INT,
+    jour_id INT,
+    menu_id INT,
+    PRIMARY KEY (client_id, jour_id, menu_id),
+    FOREIGN KEY (client_id) REFERENCES clients (id_client),
+    FOREIGN KEY (jour_id) REFERENCES jours (id_jour),
+    FOREIGN KEY (menu_id) REFERENCES menus (id_menu)
+) ENGINE = InnoDB;
+
+-- =====================================
+-- Table : clients_focaccias_jours
+-- Relation ternaire
+-- =====================================
+CREATE TABLE clients_focaccias_jours (
+    client_id INT,
+    focaccia_id INT,
+    jour_id INT,
+    PRIMARY KEY (
+        client_id,
+        focaccia_id,
+        jour_id
+    ),
+    FOREIGN KEY (client_id) REFERENCES clients (id_client),
+    FOREIGN KEY (focaccia_id) REFERENCES focaccias (id_focaccia),
+    FOREIGN KEY (jour_id) REFERENCES jours (id_jour)
+) ENGINE = InnoDB;

--- a/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/create_user_tifosi.sql
+++ b/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/create_user_tifosi.sql
@@ -1,0 +1,9 @@
+-- 🔐 Script SQL — Création de l’utilisateur ‘tifosi’
+
+CREATE USER 'tifosi' @'localhost' IDENTIFIED BY 'TifosiPwd_24';
+
+GRANT ALL PRIVILEGES ON tifosi.* TO 'tifosi' @'localhost';
+
+REVOKE GRANT OPTION ON tifosi.* FROM 'tifosi' @'localhost';
+
+FLUSH PRIVILEGES;

--- a/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/init_v012.sql
+++ b/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/init_v012.sql
@@ -1,0 +1,10 @@
+-- 🛠️ Initialisation complète de la version v0.1.2 de la base Tifosi
+-- Exécute ce script depuis la racine du répertoire `sql-v0.1.2/` dans MySQL Workbench ou autre client
+
+-- Début : création de la base et des tables
+SOURCE ./create_tifosi.sql;
+
+-- Ensuite : création de l’utilisateur `tifosi` et attribution des droits
+SOURCE ./create_user_tifosi.sql;
+
+-- 📌 Fin de l’initialisation


### PR DESCRIPTION
Partial fix #5 (2b) — Création de l’utilisateur `tifosi` et sécurisation de la base `tifosi_v011`

🎯 Étape 2b de l’issue #5 : sécurisation de la base `tifosi_v011` par création du compte SQL `tifosi`.

📂 Fichiers concernés :
- `create_user_tifosi.sql` — script de création du compte
- `init_v012.sql` — initialisation automatisée de la base + utilisateur
- `README_user-v0.1.2.md` — définition et justification des droits
- `README_test-v0.1.2.md` — protocole de test de privilèges
- `MPD-v0.1.2_tifosi.md` — fiche version avec documentation

🛡️ Droits appliqués :
- `ALL PRIVILEGES ON tifosi_v011.*` pour `tifosi`
- `GRANT OPTION` explicitement révoqué
- accès restreint à `localhost`

📎 Base cible : `tifosi_v011` (issue de la v0.1.1)

🗂️ Suivi documentaire : changelog et historique mis à jour

✅ PR prête à merge dans `main` (dernière étape avant `v0.1.3`)
