### PR TITLE
Création de la base SQL + utilisateur - Partie 2c.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,12 @@ Versionnage selon [Semantic Versioning](https://semver.org/lang/fr/).
 - Ajout de l’historique technique : `HISTORIQUE_sql.md`
 - Suivi dans l’issue #5
 
+- 🧹 Correctifs post-vérification de v0.1.2 :
+  - Ajout de `DROP DATABASE IF EXISTS` dans `create_tifosi.sql`
+  - Refonte du script `create_user_tifosi.sql` pour qu’il soit réutilisable sans erreur
+  - Suppression de la commande `REVOKE` inopérante
+  - Clarification dans `README_test-v0.1.2.md` des méthodes PowerShell / CMD
+
 🗂️ Dossiers concernés : `/docs/implementation/`, `/sql/`
 
 #### 🚧 Etape [Unreleased] [Phase 2 - v0.2]

--- a/docs/implementation/sql/HISTORIQUE_sql.md
+++ b/docs/implementation/sql/HISTORIQUE_sql.md
@@ -72,6 +72,15 @@ Cette étape intermédiaire a été décomposée plus précisément en :
 - Rédaction des fichiers de définition (`README_user`) et de test (`README_test`)
 - Documentation complète dans `MPD-v0.1.2_tifosi.md`
 
+> 🛠️ Correctif post-tests :
+>
+> - Ajout de la suppression conditionnelle de la base (`DROP DATABASE IF EXISTS`) dans `create_tifosi.sql`
+> - Réécriture de `create_user_tifosi.sql` avec :
+>
+>   - `DROP USER IF EXISTS` (réinitialisable)
+>   - suppression de la commande `REVOKE` (inutile car aucun droit de délégation accordé)
+>   - attribution ciblée des droits sur `tifosi_v011.*`
+
 📎 Fichiers produits :
 
 - `create_user_tifosi.sql`

--- a/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/MPD-v0.1.2_tifosi.md
+++ b/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/MPD-v0.1.2_tifosi.md
@@ -32,8 +32,7 @@ La structure relationnelle (tables, clés, relations N:N) est strictement identi
   - `clients_focaccias_jours`
 - Contraintes : clés primaires, clés étrangères, unicité
 
-📎 Structure initialement définie dans :  
-[`MPD-v0.1.1_tifosi.md`](../sql-v0.1.1/MPD-v0.1.1_tifosi.md)
+📎 Structure initialement définie dans : [`MPD-v0.1.1_tifosi.md`](../sql-v0.1.1/MPD-v0.1.1_tifosi.md)
 
 ---
 
@@ -46,6 +45,8 @@ La structure relationnelle (tables, clés, relations N:N) est strictement identi
 - Droit de délégation (`GRANT OPTION`) : **révoqué**
 - Limitation à l’hôte : `'localhost'`
 - Mot de passe : défini dans le script selon les consignes de sécurité
+
+> 🧠 Remarque : Le droit de délégation (GRANT OPTION) n'est pas attribué à l’utilisateur tifosi lors de l'accord des privilèges. Par conséquent, aucune révocation explicite n’est nécessaire.
 
 ### 📎 Documentation associée
 
@@ -69,9 +70,9 @@ Ce script enchaîne deux étapes :
 
 📌 Commande d’exécution recommandée (depuis le terminal) :
 
-Début bash :  
+```bash  
 mysql -u root -p < init_v012.sql  
-Fin bash
+```
 
 ⚠️ Remarque : le script doit être exécuté par un utilisateur SQL disposant des droits `CREATE`, `CREATE USER` et `GRANT`.
 

--- a/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/README_test-v0.1.2.md
+++ b/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/README_test-v0.1.2.md
@@ -5,7 +5,7 @@
 - [🧪 Tests de validation — Étape v0.1.2](#-tests-de-validation--étape-v012)
   - [🎯 Objectif](#-objectif)
   - [🚀 Initialisation complète](#-initialisation-complète)
-  - [🧪 Protocole de test](#-protocole-de-test)
+  - [🧪 Protocole de test (terminal)](#-protocole-de-test-terminal)
   - [✅ Résultats attendus](#-résultats-attendus)
   - [📎 Fichiers liés](#-fichiers-liés)
 
@@ -23,11 +23,13 @@ Avant de tester les droits de l’utilisateur `tifosi`, il est possible d’init
 
 Fichier : `init_v012.sql`
 
-Commande d’exécution depuis le terminal :
+Commande d’exécution depuis le terminal (**CMD** ou Git Bash) :
 
-Début bash :  
+```bash  
 mysql -u root -p < init_v012.sql  
-Fin bash
+```
+
+>⚠️ En environnement PowerShell, cette commande renverra une erreur (< non reconnu). Dans ce cas, passez d'abord en console CMD avec la commande : _cmd_
 
 Ce script exécute successivement :
 
@@ -38,13 +40,15 @@ La base est alors prête à être utilisée avec l’utilisateur `tifosi` pour l
 
 ---
 
-## 🧪 Protocole de test
+## 🧪 Protocole de test (terminal)
 
 1. Connexion à MySQL avec l’utilisateur `tifosi` :
 
     ```bash
     mysql -u tifosi -p
     ```
+
+    >⚠️ Le mot de passe : TifosiPwd_24
 
 2. Accès à la base `tifosi_v011` :
 
@@ -53,6 +57,10 @@ La base est alors prête à être utilisée avec l’utilisateur `tifosi` pour l
     USE tifosi_v011;
     ```
 
+    > ⚠️ Sortie attendue :
+    > - La base tifosi_v011 est visible
+    > - Les bases système (mysql, information_schema…) ne sont pas visibles.
+
 3. Test des droits complets sur la base :
 
     ```sql
@@ -60,8 +68,9 @@ La base est alors prête à être utilisée avec l’utilisateur `tifosi` pour l
     INSERT INTO test_table VALUES (1);
     SELECT * FROM test_table;
     DROP TABLE test_table;
-    Fin SQL
     ```
+
+    > ⚠️ Sortie attendue : Aucune erreur. Toutes les opérations sont autorisées.
 
 4. Vérification de l’absence de droits sur les bases système :
 
@@ -69,11 +78,15 @@ La base est alors prête à être utilisée avec l’utilisateur `tifosi` pour l
     USE mysql;
     ```
 
+    > ⚠️ Sortie attendue : Erreur 1044 : Access denied for user 'tifosi'...
+
 5. Vérification de l’impossibilité de délégation des droits :
 
     ```sql
     GRANT SELECT ON tifosi_v011.* TO 'autre_user'@'localhost';
     ```
+
+    > ⚠️ Sortie attendue : Erreur 1044 ou 1142 (droit GRANT non accordé à tifosi).
 
 ---
 

--- a/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/README_user-v0.1.2.md
+++ b/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/README_user-v0.1.2.md
@@ -46,7 +46,8 @@ FLUSH PRIVILEGES;
 🔎 Justification :
 
 - `GRANT ALL PRIVILEGES ON tifosi.*` permet à `tifosi` de gérer les objets de la base : création, modification, suppression.
-- Le `REVOKE GRANT OPTION` désactive la capacité à transférer ses droits à d’autres comptes.
+- La commande `GRANT` n’inclut pas automatiquement le droit de délégation (`GRANT OPTION`) — sauf si on l’ajoute explicitement. 
+Par conséquent, aucune révocation n’est nécessaire, car `tifosi` ne dispose pas du droit de délégation à l’origine.
 - Ces droits respectent strictement la phrase du sujet : *“tous les droits sur la base de données tifosi”* — sans extrapoler à des privilèges d’administration serveur.
 
 ---

--- a/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/create_tifosi.sql
+++ b/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/create_tifosi.sql
@@ -2,8 +2,11 @@
 -- Auteur : PerLucCo
 -- Date : 2025-06-24
 
+-- ⚠️ Réinitialisation de la base (supprime toutes les données existantes)
+DROP DATABASE IF EXISTS tifosi_v011;
+
 -- 🔧 Création de la base
-CREATE DATABASE IF NOT EXISTS tifosi_v011 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE DATABASE tifosi_v011 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 
 USE tifosi_v011;
 

--- a/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/create_user_tifosi.sql
+++ b/docs/implementation/sql/sql-v0.1/versions/sql-v0.1.2/create_user_tifosi.sql
@@ -1,9 +1,16 @@
--- 🔐 Script SQL — Création de l’utilisateur ‘tifosi’
+-- 🔐 Script SQL — Création ou recréation de l’utilisateur 'tifosi'
+-- Version robuste (réinitialisable)
+-- Auteur : PerLucCo
+-- Date : 2025-06-25
 
+-- 🧼 Suppression préalable si l’utilisateur existe
+DROP USER IF EXISTS 'tifosi' @'localhost';
+
+-- 🆕 Création de l’utilisateur avec mot de passe sécurisé
 CREATE USER 'tifosi' @'localhost' IDENTIFIED BY 'TifosiPwd_24';
 
-GRANT ALL PRIVILEGES ON tifosi.* TO 'tifosi' @'localhost';
+-- 🎓 Attribution complète des droits sur la base tifosi_v011
+GRANT ALL PRIVILEGES ON tifosi_v011.* TO 'tifosi' @'localhost';
 
-REVOKE GRANT OPTION ON tifosi.* FROM 'tifosi' @'localhost';
-
+-- 🔄 Application immédiate des privilèges
 FLUSH PRIVILEGES;


### PR DESCRIPTION
Partial fix #5 (2c) — Corrections post-tests v0.1.2 : scripts SQL et documentation

🔧 Suite aux tests manuels réalisés via terminal (CMD), MySQL Workbench et phpMyAdmin, plusieurs ajustements ont été apportés à la version v0.1.2.

🎯 Objectif :
Stabiliser les scripts SQL et la documentation de la version v0.1.2 avant passage à la v0.1.3.

🛠️ Modifications apportées :
- `create_tifosi.sql` :
  - ajout de `DROP DATABASE IF EXISTS tifosi_v011;` (réinitialisation propre)
- `create_user_tifosi.sql` :
  - ajout de `DROP USER IF EXISTS 'tifosi'@'localhost';` (script réutilisable)
  - suppression de `REVOKE` superflu (droit de délégation jamais attribué)
- `README_test-v0.1.2.md` :
  - clarification des conditions de test manuel
  - ajout des remarques PowerShell / CMD
  - description des cas d’erreur attendus
- `README_user-v0.1.2.md` :
  - justification de l’absence de `GRANT OPTION`
- `MPD-v0.1.2_tifosi.md` :
  - ajout d’une note d’analyse sur la délégation

📌 PR préparatoire à la livraison `v0.1.3` (création de la base complète `tifosi_v013`)
📎 Issue liée : #5
